### PR TITLE
Refactor renovate config

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,5 @@
   },
   "engines": {
     "node": ">=6.4.0"
-  },
-  "renovate": {
-    "extends": [
-      "config:base",
-      ":preserveSemverRanges",
-      ":rebaseStalePrs"
-    ]
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,8 @@
+{
+    "extends": [
+      "config:base",
+      ":preserveSemverRanges",
+      ":rebaseStalePrs"
+    ],
+    "renovateFork": true
+}


### PR DESCRIPTION
For a forked repository like this, you need to put config in `renovate.json` and include `"renovateFork": true`, otherwise it gets ignored. I added a server-side rule to try to work around this anyway but it's best if you accept this PR to move your config.